### PR TITLE
Fix fib ts lint

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,15 +1,17 @@
 // Endpoint for querying the fibonacci numbers
 
+import { Request, Response } from "express";
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req: Request<{ num: string }>, res: Response) => {
   const { num } = req.params;
+  const n = parseInt(num, 10);
 
-  const fibN = fibonacci(parseInt(num));
-  let result = `fibonacci(${num}) is ${fibN}`;
+  const fibN = fibonacci(n);
+  let result = `fibonacci(${n}) is ${fibN}`;
 
   if (fibN < 0) {
-    result = `fibonacci(${num}) is undefined`;
+    result = `fibonacci(${n}) is undefined`;
   }
 
   res.send(result);

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,4 +1,4 @@
-// Endpoint for querying the fibonacci numbers
+// Endpoint for querying the fibonacci numbers 
 
 import { Request, Response } from "express";
 import fibonacci from "./fib";


### PR DESCRIPTION
The changes include importing Request and Response types from Express, and typing the handler parameters as Request and Response. This properly types req.params.num as a string, eliminating the unsafe member access and assignment errors. Additionally, the route param is now parsed to a number and stored in a variable n before being used in template literals and passed to the fibonacci() function. This fixes the restrict-template-expressions and unsafe-argument errors.

The changes have been tested by running npm run lint, which now passes with no errors. All 4 existing unit tests also pass when running npm test.